### PR TITLE
Throw exception when authentication fails

### DIFF
--- a/zimbra-extension/src/com/zextras/zimbradrive/NcUserZimbraBackendHttpHandler.java
+++ b/zimbra-extension/src/com/zextras/zimbradrive/NcUserZimbraBackendHttpHandler.java
@@ -82,6 +82,7 @@ public class NcUserZimbraBackendHttpHandler implements HttpHandler
     } else
     {
       ZimbraLog.security.warn(mZimbraDriveLog.getLogIntroduction() + "Authentication failed for user '" + userId + "'");
+      throw new ServletException();
     }
   }
 


### PR DESCRIPTION
The POST handler catches exceptions to return 500, indicating that authentication failed.
In case of authentication failure, however, the function returns normally.
This causes post to return with 200, but without any payload, which breaks the Nextcloud app.