### PR TITLE
Moved setDefaultUserAttributes

### DIFF
--- a/nextcloud-app/lib/auth/abstractzimbrausersbackend.php
+++ b/nextcloud-app/lib/auth/abstractzimbrausersbackend.php
@@ -96,9 +96,9 @@ abstract class AbstractZimbraUsersBackend extends \OC_User_Backend
             if(!$this->userManager->userExists($zimbraUser->getUid()))
             {
                 $this->createUser($zimbraUser->getUid(), $zimbraUser->getDisplayName());
+                $this->setDefaultUserAttributes($zimbraUser);
             }
-            $this->setDefaultUserAttributes($zimbraUser);
-
+            
             return $zimbraUser->getUid();
         } catch (\Exception $ignore)
         {


### PR DESCRIPTION
Moved setDefaultUserAttributes to set it only when the user not exists and its created.
Before this change, every time a zimbra user logs reset its attributes, and makes the manager of owncloud try to create the user again even if it exists. 
It makes it fail and drive to stop working.