### PR TITLE
Update zimbraauthenticationbackendimpl.php

### DIFF
--- a/nextcloud-app/lib/auth/zimbraauthenticationbackendimpl.php
+++ b/nextcloud-app/lib/auth/zimbraauthenticationbackendimpl.php
@@ -51,7 +51,9 @@ class ZimbraAuthenticationBackendImpl implements ZimbraAuthenticationBackend
         {
             throw new AuthenticationException();
         }
-        $response = json_decode($httpRequestResponse->getRawResponse());
+        $rawResponse = $httpRequestResponse->getRawResponse();
+        $rawResponse = utf8_encode($rawResponse);
+        $response = json_decode($rawResponse);
         $userId = $response->{'accountId'};
         $userDisplayName = $response->{'displayName'};
         $userEmail = $response->{'email'};


### PR DESCRIPTION
It was unpossible to login when a username had german umlaute in it.
It shows that json_decode() failed in this case.
The UTF-8 character was not interpreted correct.
An additional conversion was needed.
Now it works as expected.