### PR TITLE
Update ZimbraDriveItem.ts

### DIFF
--- a/zimlet/src/ZimbraDriveItem.ts
+++ b/zimlet/src/ZimbraDriveItem.ts
@@ -131,7 +131,11 @@ export class ZimbraDriveItem extends ZmItem {
   }
 
   public getAuthor(): string {
-    return this.author;
+    //If Autor is Empty then return string with space. " ". 
+   if (empty(this.author)) {
+      return "";} else {
+             return this.author;
+        }
   }
 
   public getPath(urlEncode?: boolean): string {


### PR DESCRIPTION
Fix Error with Next Cloud Shared Folder Plug In -  This is not sending Author.
If this field is empty then return a space " ". 

org.json.JSONException: JSONObject["author"] not a string.

at org.eclipse.jetty.rewrite.handler.RewriteHandler.handle(RewriteHandler.java:318)
at org.eclipse.jetty.server.handler.gzip.GzipHandler.handle(GzipHandler.java:437)
at org.eclipse.jetty.server.handler.DebugHandler.handle(DebugHandler.java:84)
at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:119)
at org.eclipse.jetty.server.Server.handle(Server.java:517)
at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:306)
at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:242)
at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:261)
at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:95)
at org.eclipse.jetty.io.ssl.SslConnection.onFillable(SslConnection.java:192)
at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:261)
at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:95)
at org.eclipse.jetty.io.SelectChannelEndPoint$2.run(SelectChannelEndPoint.java:75)
at org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume.produceAndRun(ExecuteProduceConsume.java:213)
at org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume.run(ExecuteProduceConsume.java:147)
at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:654)
at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:572)
at java.lang.Thread.run(Thread.java:748)
Caused by: org.json.JSONException: JSONObject["author"] not a string.
at org.json.JSONObject.getString(JSONObject.java:721)
at com.zextras.zimbradrive.soap.JsonToSoapUtils.appendSoapValueFromDriveResponseFolder(JsonToSoapUtils.java:31)
at com.zextras.zimbradrive.soap.JsonToSoapUtils.appendSoapValueFromDriveResponseFolder(JsonToSoapUtils.java:49)
at com.zextras.zimbradrive.soap.GetAllFoldersHdlr.appendSoapResponseFromDriveResponseFolder(GetAllFoldersHdlr.java:75)
at com.zextras.zimbradrive.soap.GetAllFoldersHdlr.handleRequest(GetAllFoldersHdlr.java:56)