### PR TITLE
Indicate support for Nextcloud 14 and 15

### DIFF
--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -42,7 +42,7 @@
 
     <dependencies>
         <owncloud min-version="9.0" max-version="10.0"/>
-        <nextcloud min-version="9" max-version="13"/>
+        <nextcloud min-version="9" max-version="15"/>
     </dependencies>
     <types>
         <authentication/>


### PR DESCRIPTION
I have done some basic testing in a development environment and Zimbra Drive seems to be working fine. Can you merge this and create a new release to officially add support for Nextcloud 14+?