### PR TITLE
Update owncloud max-version to 10

### DIFF
--- a/nextcloud-app/appinfo/info.xml
+++ b/nextcloud-app/appinfo/info.xml
@@ -41,7 +41,7 @@
     <screenshot>zimbra.png</screenshot>
 
     <dependencies>
-        <owncloud min-version="9.0" max-version="10.0"/>
+        <owncloud min-version="9.0" max-version="10"/>
         <nextcloud min-version="9" max-version="15"/>
     </dependencies>
     <types>


### PR DESCRIPTION
If this app works with owncloud 10.0.* then it should work with 10.1.* 10.2.* the upcoming 10.3 and any 10.*

Is there any special reason that the app was limited to owncloud `10.0.*` ?